### PR TITLE
Bug : Fix the issue of watch id without discount consider only one ir…

### DIFF
--- a/src/main/java/com/task/watch_catalogue/service/WatchCatalogueService.java
+++ b/src/main/java/com/task/watch_catalogue/service/WatchCatalogueService.java
@@ -35,7 +35,7 @@ public class WatchCatalogueService {
             int count = uniqueWatchIdWithCount.get(entity.getId());
             float unitPrice = entity.getUnitPrice();
             if (count == 1 || "".equals(entity.getDiscount())) {
-                totalPrice = totalPrice + unitPrice;
+                totalPrice = totalPrice + (count*unitPrice);
             } else {
                 String[] discount = entity.getDiscount().split(" ");
                 int discountNumber= Integer.parseInt(discount[0]);


### PR DESCRIPTION
…respective of input count

For example if the input is [003,003] and no discount for the id 003 in db then actual sum should be 2*unit price but considering only once, 1*unit price